### PR TITLE
DNS dataset: 'segment' and sr support, clean-only loading

### DIFF
--- a/asteroid/data/dns_dataset.py
+++ b/asteroid/data/dns_dataset.py
@@ -4,6 +4,8 @@ import json
 import os
 import soundfile as sf
 
+from asteroid.utils import get_wav_random_start_stop
+
 
 class DNSDataset(data.Dataset):
     """Deep Noise Suppression (DNS) Challenge's dataset.
@@ -18,9 +20,11 @@ class DNSDataset(data.Dataset):
 
     dataset_name = "DNS"
 
-    def __init__(self, json_dir):
-
+    def __init__(self, json_dir, sample_rate=16000, segment=None, load_noise=True):
         super(DNSDataset, self).__init__()
+        self.sample_rate = sample_rate
+        self.segment = segment
+        self.load_noise = load_noise
         self.json_dir = json_dir
         with open(os.path.join(json_dir, "file_infos.json"), "r") as f:
             self.mix_infos = json.load(f)
@@ -33,16 +37,39 @@ class DNSDataset(data.Dataset):
     def __getitem__(self, idx):
         """Gets a mixture/sources pair.
         Returns:
-            mixture, vstack([source_arrays])
+            (mixture, clean, noise) if self.load_noise is true, else (mixture, clean)
         """
         utt_info = self.mix_infos[self.wav_ids[idx]]
         # Load mixture
-        x = torch.from_numpy(sf.read(utt_info["mix"], dtype="float32")[0])
+        x_np, sr = sf.read(utt_info["mix"], dtype="float32")
+        assert sr == self.sample_rate
+        start, stop = get_wav_random_start_stop(
+            len(x_np), int(self.segment * self.sample_rate) if self.segment is not None else None
+        )
+        x = torch.from_numpy(x_np[start:stop])
         # Load clean
-        speech = torch.from_numpy(sf.read(utt_info["clean"], dtype="float32")[0])
-        # Load noise
-        noise = torch.from_numpy(sf.read(utt_info["noise"], dtype="float32")[0])
-        return x, speech, noise
+        speech = torch.from_numpy(
+            sf.read(utt_info["clean"], dtype="float32", start=start, stop=stop)[0]
+        )
+        if self.segment is not None:
+            x = torch.nn.functional.pad(
+                x, (0, max(0, int(self.segment * self.sample_rate) - len(x)))
+            )
+            speech = torch.nn.functional.pad(
+                speech, (0, max(0, int(self.segment * self.sample_rate) - len(speech)))
+            )
+        if self.load_noise:
+            # Load noise
+            noise = torch.from_numpy(
+                sf.read(utt_info["noise"], dtype="float32", start=start, stop=stop)[0]
+            )
+            if self.segment is not None:
+                noise = torch.nn.functional.pad(
+                    noise, (0, max(0, int(self.segment * self.sample_rate) - len(noise)))
+                )
+            return x, speech, noise
+        else:
+            return x, speech
 
     def get_infos(self):
         """Get dataset infos (for publishing models).
@@ -50,11 +77,14 @@ class DNSDataset(data.Dataset):
         Returns:
             dict, dataset infos with keys `dataset`, `task` and `licences`.
         """
-        infos = dict()
-        infos["dataset"] = self.dataset_name
-        infos["task"] = "enhancement"
-        infos["licenses"] = [dns_license]
-        return infos
+        return {
+            "dataset": self.dataset_name,
+            "sample_rate": self.sample_rate,
+            "segment": self.segment,
+            "task": "enhancement",
+            "licenses": [dns_license],
+            "n_src": 2 if self.load_noise else 1,
+        }
 
 
 dns_license = dict(


### PR DESCRIPTION
- Add support for `segment`
- Add support for loading mixture + clean only, no noise
- Had to add sample rate for `segment` implementation

The way the code deals with files that are too short is different from the other datasets (here: zero pad to the right). This needs to be discussed.