### PR TITLE
Lightning 1.x and test loops 

### DIFF
--- a/asteroid/engine/dataloader.py
+++ b/asteroid/engine/dataloader.py
@@ -9,7 +9,7 @@ def collate_fn(batch):
 
     inputs = []
     targets = []
-
+    sizes = []
     if batch is not None:
         max_len = 0
         for elm in batch:
@@ -18,33 +18,16 @@ def collate_fn(batch):
                 max_len = len(mixture)
         for elm in batch:
             mixture, sources = elm
+            sizes.append(torch.tensor(len(mixture)))
             mixture = F.pad(mixture, pad=(0, max_len - len(mixture)),
                            mode='constant', value=0)
             sources = F.pad(sources, pad=(0, max_len - sources.shape[-1]),
                                 mode='constant', value=0)
             inputs.append(mixture)
-            targets.append(sources)
+            targets.append(sources.unsqueeze(0))
     inputs = torch.vstack(inputs)
     targets = torch.vstack(targets)
-    return inputs, targets
-
-
-test_dir='../../egs/librimix/ConvTasNet/data/wav8k/max/test'
-
-test_set = LibriMix(
-    csv_dir=test_dir,
-    task='sep_clean',
-    sample_rate=8000,
-    n_src=2,
-    segment=None)
-
-test_loarder = DataLoader(
-        test_set,
-        shuffle=False,
-        batch_size=4,
-        num_workers=0,
-        drop_last=False,
-        collate_fn=collate_fn)
-
+    sizes = torch.vstack(sizes)
+    return inputs, targets, sizes
 
 

--- a/asteroid/engine/dataloader.py
+++ b/asteroid/engine/dataloader.py
@@ -1,0 +1,50 @@
+import torch
+from asteroid.data.librimix_dataset import LibriMix
+import os
+from torch.utils.data import DataLoader
+import torch.nn.functional as F
+
+
+def collate_fn(batch):
+
+    inputs = []
+    targets = []
+
+    if batch is not None:
+        max_len = 0
+        for elm in batch:
+            mixture, sources = elm
+            if len(mixture) > max_len:
+                max_len = len(mixture)
+        for elm in batch:
+            mixture, sources = elm
+            mixture = F.pad(mixture, pad=(0, max_len - len(mixture)),
+                           mode='constant', value=0)
+            sources = F.pad(sources, pad=(0, max_len - sources.shape[-1]),
+                                mode='constant', value=0)
+            inputs.append(mixture)
+            targets.append(sources)
+    inputs = torch.vstack(inputs)
+    targets = torch.vstack(targets)
+    return inputs, targets
+
+
+test_dir='../../egs/librimix/ConvTasNet/data/wav8k/max/test'
+
+test_set = LibriMix(
+    csv_dir=test_dir,
+    task='sep_clean',
+    sample_rate=8000,
+    n_src=2,
+    segment=None)
+
+test_loarder = DataLoader(
+        test_set,
+        shuffle=False,
+        batch_size=4,
+        num_workers=0,
+        drop_last=False,
+        collate_fn=collate_fn)
+
+
+


### PR DESCRIPTION
### About this PR 
This PR is a first draft on test loops using Pytorch ligthning.

### Interest 
Using lightning to perform the test step would transfer the main functionalities of the eval script to `system`. This will allow easy multiprocessing and a more consistent behavior between training and testing.

### TODO
In this first draft, some functionalities from the eval script are still missing. 

- The metrics are not saved to disk (not hard to do)

- Currently, the path of the mixtures is added to `all_metrics` I don't think it's possible to do that when using batched data without changing the outputs of the dataset (here `asteroid/data/librimix_dataset.py`)

As we are going to use Lightning 1.x we will be able to refactor the datasets and take advantage of `LightningDataModule` which will be useful for the last point. 