### PR TITLE
Remove call to super().training_step()

### DIFF
--- a/asteroid/engine/system.py
+++ b/asteroid/engine/system.py
@@ -111,7 +111,6 @@ class System(pl.LightningModule):
         Returns:
             torch.Tensor, the value of the loss.
         """
-        super().training_step()
         loss = self.common_step(batch, batch_nb, train=True)
         self.log("loss", loss, logger=True)
         return loss


### PR DESCRIPTION
The base implementation now throws a warning, see https://github.com/PyTorchLightning/pytorch-lightning/blob/81fd33b431578129de6ea19b99af7da87b1081bf/pytorch_lightning/core/lightning.py#L502