### PR TITLE
#Minor Fixes final checkpoint save for wsj0-mix DeepClustering example.

### DIFF
--- a/egs/kinect-wsj/DeepClustering/train.py
+++ b/egs/kinect-wsj/DeepClustering/train.py
@@ -78,7 +78,7 @@ def main(conf):
     with open(os.path.join(exp_dir, "best_k_models.json"), "w") as f:
         json.dump(checkpoint.best_k_models, f, indent=0)
     # Save last model for convenience
-    torch.save(system.model.state_dict(), os.path.join(exp_dir, "checkpoints/final.pth"))
+    torch.save(system.model.state_dict(), os.path.join(exp_dir, "final_model.pth"))
 
 
 # TODO:Should ideally be inherited from wsj0-mix

--- a/egs/wsj0-mix/DeepClustering/train.py
+++ b/egs/wsj0-mix/DeepClustering/train.py
@@ -80,7 +80,7 @@ def main(conf):
     with open(os.path.join(exp_dir, "best_k_models.json"), "w") as f:
         json.dump(best_k, f, indent=0)
     # Save last model for convenience
-    torch.save(system.model.state_dict(), os.path.join(exp_dir, "best_model.pth"))
+    torch.save(system.model.state_dict(), os.path.join(exp_dir, "final_model.pth"))
 
 
 class ChimeraSystem(System):

--- a/egs/wsj0-mix/DeepClustering/train.py
+++ b/egs/wsj0-mix/DeepClustering/train.py
@@ -80,7 +80,7 @@ def main(conf):
     with open(os.path.join(exp_dir, "best_k_models.json"), "w") as f:
         json.dump(best_k, f, indent=0)
     # Save last model for convenience
-    torch.save(system.model.state_dict(), os.path.join(exp_dir, "checkpoints/final.pth"))
+    torch.save(system.model.state_dict(), os.path.join(exp_dir, "best_model.pth"))
 
 
 class ChimeraSystem(System):


### PR DESCRIPTION
Makes `wsj0-mix/DeepClustering` final save like `wham/DPTNet`.

[PyTorch Lightning's `pytorch_lightning.callbacks.ModelCheckpoint`](https://pytorch-lightning.readthedocs.io/en/stable/generated/pytorch_lightning.callbacks.ModelCheckpoint.html) assumes `dirpath + filename` not a `dirpath` as its first argument, but line 83 assumes a `checkpoints` folder exists.

So when this example runs this error occurs:

```
Epoch 132: 100%|█████████▉| 666/667 [04:11<00:00,  2.65it/s, Epoch 132, step 70888: val_loss was not in top 5
Epoch 132: 100%|██████████| 667/667 [04:11<00:00,  2.65it/s, loss=2.07e+03, v_num=0]
Traceback (most recent call last):
  File "train.py", line 202, in <module>
    main(arg_dic)
  File "train.py", line 83, in main
    torch.save(system.model.state_dict(), os.path.join(exp_dir, "checkpoints/final.pth"))
  File "/opt/conda/lib/python3.8/site-packages/torch/serialization.py", line 369, in save
    with _open_file_like(f, 'wb') as opened_file:
  File "/opt/conda/lib/python3.8/site-packages/torch/serialization.py", line 230, in _open_file_like
    return _open_file(name_or_buffer, mode)
  File "/opt/conda/lib/python3.8/site-packages/torch/serialization.py", line 211, in __init__
    super(_open_file, self).__init__(open(name, mode))
FileNotFoundError: [Errno 2] No such file or directory: 'exp/train_chimera_2sep_8kmin_be1bb623/checkpoints/final.pth'
```

since the directory structure looks like:

```
# ls exp/train_chimera_2sep_8kmin_be1bb623
best_k_models.json   checkpoints-v1.ckpt  checkpoints-v3.ckpt  conf.yml        run_uuid.txt
checkpoints-v0.ckpt  checkpoints-v2.ckpt  checkpoints.ckpt     lightning_logs
```

I'm using pytorch_lightning version '1.1.2' with pytorch 1.8.0a0+1606899.
