### PR TITLE
Add stft_n_filters to BaseDCUNet

### DIFF
--- a/asteroid/models/dccrnet.py
+++ b/asteroid/models/dccrnet.py
@@ -21,11 +21,14 @@ class DCCRNet(BaseDCUNet):
 
     masknet_class = DCCRMaskNet
 
-    def __init__(self, *args, stft_kernel_size=512, **masknet_kwargs):
+    def __init__(self, *args, stft_n_filters=512, stft_kernel_size=400,
+                 stft_stride=100, **masknet_kwargs):
         masknet_kwargs.setdefault("n_freqs", stft_kernel_size // 2)
         super().__init__(
             *args,
+            stft_n_filters=stft_n_filters,
             stft_kernel_size=stft_kernel_size,
+            stft_stride=stft_stride,
             **masknet_kwargs,
         )
 

--- a/asteroid/models/dccrnet.py
+++ b/asteroid/models/dccrnet.py
@@ -23,7 +23,7 @@ class DCCRNet(BaseDCUNet):
 
     def __init__(self, *args, stft_n_filters=512, stft_kernel_size=400,
                  stft_stride=100, **masknet_kwargs):
-        masknet_kwargs.setdefault("n_freqs", stft_kernel_size // 2)
+        masknet_kwargs.setdefault("n_freqs", stft_n_filters // 2)
         super().__init__(
             *args,
             stft_n_filters=stft_n_filters,

--- a/asteroid/models/dccrnet.py
+++ b/asteroid/models/dccrnet.py
@@ -21,8 +21,9 @@ class DCCRNet(BaseDCUNet):
 
     masknet_class = DCCRMaskNet
 
-    def __init__(self, *args, stft_n_filters=512, stft_kernel_size=400,
-                 stft_stride=100, **masknet_kwargs):
+    def __init__(
+        self, *args, stft_n_filters=512, stft_kernel_size=400, stft_stride=100, **masknet_kwargs
+    ):
         masknet_kwargs.setdefault("n_freqs", stft_n_filters // 2)
         super().__init__(
             *args,

--- a/asteroid/models/dcunet.py
+++ b/asteroid/models/dcunet.py
@@ -70,7 +70,7 @@ class DCUNet(BaseDCUNet):
         architecture (str): The architecture to use, any of
             "DCUNet-10", "DCUNet-16", "DCUNet-20", "Large-DCUNet-20".
         stft_n_filters (int) Number of filters for the STFT.
-        stft_kernel_size (int): STFT frame length to use
+        stft_kernel_size (int): STFT frame length to use.
         stft_stride (int, optional): STFT hop length to use.
         sample_rate (float): Sampling rate of the model.
         masknet_kwargs (optional): Passed to :class:`DCUMaskNet`

--- a/asteroid/models/dcunet.py
+++ b/asteroid/models/dcunet.py
@@ -9,7 +9,8 @@ class BaseDCUNet(BaseEncoderMaskerDecoder):
 
     Args:
         architecture (str): The architecture to use. Overriden by subclasses.
-        stft_kernel_size (int): STFT frame length to use
+        stft_n_filters (int) Number of filters for the STFT.
+        stft_kernel_size (int): STFT frame length to use.
         stft_stride (int, optional): STFT hop length to use.
         sample_rate (float): Sampling rate of the model.
         masknet_kwargs (optional): Passed to the masknet constructor.
@@ -20,12 +21,14 @@ class BaseDCUNet(BaseEncoderMaskerDecoder):
     def __init__(
         self,
         architecture,
-        stft_kernel_size=512,
-        stft_stride=None,
+        stft_n_filters=1024,
+        stft_kernel_size=1024,
+        stft_stride=256,
         sample_rate=16000.0,
         **masknet_kwargs,
     ):
         self.architecture = architecture
+        self.stft_n_filters = stft_n_filters
         self.stft_kernel_size = stft_kernel_size
         self.stft_stride = stft_stride
         self.masknet_kwargs = masknet_kwargs
@@ -33,7 +36,7 @@ class BaseDCUNet(BaseEncoderMaskerDecoder):
         encoder, decoder = make_enc_dec(
             "stft",
             kernel_size=stft_kernel_size,
-            n_filters=stft_kernel_size,
+            n_filters=stft_n_filters,
             stride=stft_stride,
             sample_rate=sample_rate,
         )
@@ -66,6 +69,7 @@ class DCUNet(BaseDCUNet):
     Args:
         architecture (str): The architecture to use, any of
             "DCUNet-10", "DCUNet-16", "DCUNet-20", "Large-DCUNet-20".
+        stft_n_filters (int) Number of filters for the STFT.
         stft_kernel_size (int): STFT frame length to use
         stft_stride (int, optional): STFT hop length to use.
         sample_rate (float): Sampling rate of the model.

--- a/asteroid/models/dcunet.py
+++ b/asteroid/models/dcunet.py
@@ -35,8 +35,8 @@ class BaseDCUNet(BaseEncoderMaskerDecoder):
 
         encoder, decoder = make_enc_dec(
             "stft",
-            kernel_size=stft_kernel_size,
             n_filters=stft_n_filters,
+            kernel_size=stft_kernel_size,
             stride=stft_stride,
             sample_rate=sample_rate,
         )
@@ -55,6 +55,7 @@ class BaseDCUNet(BaseEncoderMaskerDecoder):
         """Arguments needed to re-instantiate the model."""
         model_args = {
             "architecture": self.architecture,
+            "stft_n_filters": self.stft_n_filters,
             "stft_kernel_size": self.stft_kernel_size,
             "stft_stride": self.stft_stride,
             "sample_rate": self.sample_rate,

--- a/tests/jit/jit_models_test.py
+++ b/tests/jit/jit_models_test.py
@@ -58,7 +58,9 @@ def small_model_params():
             "stride": 16,
         },
         DCCRNet.__name__: {
+            "stft_n_filters": 512,
             "stft_kernel_size": 256,
+            "stft_stride": 100,
             "architecture": "mini",
         },
         DeMask.__name__: {
@@ -123,7 +125,6 @@ def test_enhancement_model(small_model_params, model_def, test_data):
     # Random input uniformly distributed in [-1, 1]
     inputs = ((torch.rand(1, 2500, device=device) - 0.5) * 2,)
     traced = torch.jit.trace(model, inputs)
-
     assert_consistency(model=model, traced=traced, tensor=test_data.to(device))
 
 

--- a/tests/models/models_test.py
+++ b/tests/models/models_test.py
@@ -155,8 +155,8 @@ def test_dptnet(fb):
 
 
 def test_dcunet():
-    _, istft = make_enc_dec("stft", 512, 512)
-    input_samples = istft(torch.zeros((514, 17))).shape[0]
+    _, istft = make_enc_dec("stft", 1024, 1024, 256, 16000)
+    input_samples = istft(torch.zeros((1026, 17))).shape[0]
     _default_test_model(DCUNet("DCUNet-10"), input_samples=input_samples)
     _default_test_model(DCUNet("DCUNet-10", n_src=2), input_samples=input_samples)
 
@@ -173,7 +173,7 @@ def test_dcunet():
 
 
 def test_dccrnet():
-    _, istft = make_enc_dec("stft", 512, 512)
+    _, istft = make_enc_dec("stft", 512, 400, 100,16000)
     input_samples = istft(torch.zeros((514, 16))).shape[0]
     _default_test_model(DCCRNet("DCCRN-CL"), input_samples=input_samples)
     _default_test_model(DCCRNet("DCCRN-CL", n_src=2), input_samples=input_samples)

--- a/tests/models/models_test.py
+++ b/tests/models/models_test.py
@@ -173,7 +173,7 @@ def test_dcunet():
 
 
 def test_dccrnet():
-    _, istft = make_enc_dec("stft", 512, 400, 100,16000)
+    _, istft = make_enc_dec("stft", 512, 400, 100, 16000)
     input_samples = istft(torch.zeros((514, 16))).shape[0]
     _default_test_model(DCCRNet("DCCRN-CL"), input_samples=input_samples)
     _default_test_model(DCCRNet("DCCRN-CL", n_src=2), input_samples=input_samples)

--- a/tests/models/models_test.py
+++ b/tests/models/models_test.py
@@ -155,8 +155,11 @@ def test_dptnet(fb):
 
 
 def test_dcunet():
-    _, istft = make_enc_dec("stft", 1024, 1024, 256, 16000)
-    input_samples = istft(torch.zeros((1026, 17))).shape[0]
+    n_fft = 1024
+    _, istft = make_enc_dec(
+        "stft", n_filters=n_fft, kernel_size=1024, stride=256, sample_rate=16000
+    )
+    input_samples = istft(torch.zeros((n_fft + 2, 17))).shape[0]
     _default_test_model(DCUNet("DCUNet-10"), input_samples=input_samples)
     _default_test_model(DCUNet("DCUNet-10", n_src=2), input_samples=input_samples)
 
@@ -173,8 +176,9 @@ def test_dcunet():
 
 
 def test_dccrnet():
-    _, istft = make_enc_dec("stft", 512, 400, 100, 16000)
-    input_samples = istft(torch.zeros((514, 16))).shape[0]
+    n_fft = 512
+    _, istft = make_enc_dec("stft", n_filters=n_fft, kernel_size=400, stride=100, sample_rate=16000)
+    input_samples = istft(torch.zeros((n_fft + 2, 16))).shape[0]
     _default_test_model(DCCRNet("DCCRN-CL"), input_samples=input_samples)
     _default_test_model(DCCRNet("DCCRN-CL", n_src=2), input_samples=input_samples)
 


### PR DESCRIPTION
This PR adds `stft_n_filters` as mentionned in #404.
It also fixes the defaults parameter of DCUNet to match its paper as mentionned in #400 