### PR TITLE
[src] Change n_channels to in_channels

### DIFF
--- a/asteroid/dsp/overlap_add.py
+++ b/asteroid/dsp/overlap_add.py
@@ -66,7 +66,7 @@ class LambdaOverlapAdd(torch.nn.Module):
         self.window_size = window_size
         self.hop_size = hop_size if hop_size is not None else window_size // 2
         self.n_src = n_src
-        self.n_channels = getattr(nnet, "n_channels", None)
+        self.in_channels = getattr(nnet, "in_channels", None)
 
         if window:
             from scipy.signal import get_window  # for torch.hub

--- a/asteroid/models/base_models.py
+++ b/asteroid/models/base_models.py
@@ -33,14 +33,14 @@ class BaseModel(torch.nn.Module):
 
     Args:
         sample_rate (float): Operating sample rate of the model.
-        n_channels: Supported number of channels of the model.
+        in_channels: Number of input channels in the signal.
             If None, no checks will be performed.
     """
 
-    def __init__(self, sample_rate: float = 8000.0, n_channels: Optional[int] = 1):
+    def __init__(self, sample_rate: float = 8000.0, in_channels: Optional[int] = 1):
         super().__init__()
         self.__sample_rate = sample_rate
-        self.n_channels = n_channels
+        self.in_channels = in_channels
 
     def forward(self, *args, **kwargs):
         raise NotImplementedError

--- a/asteroid/separate.py
+++ b/asteroid/separate.py
@@ -20,7 +20,7 @@ from .utils import get_device
 class Separatable(Protocol):
     """Things that are separatable."""
 
-    n_channels: Optional[int]
+    in_channels: Optional[int]
 
     def forward_wav(self, wav: torch.Tensor, **kwargs) -> torch.Tensor:
         """
@@ -91,9 +91,9 @@ def separate(
 @torch.no_grad()
 def torch_separate(model: Separatable, wav: torch.Tensor, **kwargs) -> torch.Tensor:
     """Core logic of `separate`."""
-    if model.n_channels is not None and wav.shape[-2] != model.n_channels:
+    if model.in_channels is not None and wav.shape[-2] != model.in_channels:
         raise RuntimeError(
-            f"Model supports {model.n_channels}-channel inputs but found audio with {wav.shape[-2]} channels."
+            f"Model supports {model.in_channels}-channel inputs but found audio with {wav.shape[-2]} channels."
             f"Please match the number of channels."
         )
     # Handle device placement

--- a/tests/models/models_test.py
+++ b/tests/models/models_test.py
@@ -34,20 +34,20 @@ def test_set_sample_rate_raises_warning():
 
 def test_multichannel_model_loading():
     class MCModel(BaseModel):
-        def __init__(self, sample_rate=8000.0, n_channels=2):
-            super().__init__(sample_rate=sample_rate, n_channels=n_channels)
+        def __init__(self, sample_rate=8000.0, in_channels=2):
+            super().__init__(sample_rate=sample_rate, in_channels=in_channels)
 
         def forward(self, x, **kwargs):
             return x
 
         def get_model_args(self):
-            return {"sample_rate": self.sample_rate, "n_channels": self.n_channels}
+            return {"sample_rate": self.sample_rate, "in_channels": self.in_channels}
 
     model = MCModel()
     model_conf = model.serialize()
 
     new_model = MCModel.from_pretrained(model_conf)
-    assert model.n_channels == new_model.n_channels
+    assert model.in_channels == new_model.in_channels
 
 
 def test_convtasnet_sep():


### PR DESCRIPTION
This was pointed out by @jonashaag as a potential name. 

I was against using `out_channels` instead of `n_src` and ruled out `in_channels` in the same time. Got back to it, I think `in_channels` makes more sense and is more consistent with PyTorch's code, so it's better. 