### PR TITLE
fix a bug in 00_GettingStarted.ipynb

### DIFF
--- a/notebooks/00_GettingStarted.ipynb
+++ b/notebooks/00_GettingStarted.ipynb
@@ -1248,8 +1248,9 @@
         "model = BaseModel.from_pretrained(\"mpariente/DPRNNTasNet-ks2_WHAM_sepclean\")\n",
         "\n",
         "# You can pass a NumPy array:\n",
-        "mixture, _ = sf.read(\"female-female-mixture.wav\", dtype=\"float32\")\n",
-        "model.separate(mixture)\n",
+        "mixture, _ = sf.read(\"female-female-mixture.wav\", dtype=\"float32\", always_2d=True)\n",
+        "mixture = mixture.T\n",
+        "out_wavs = model.separate(mixture)\n",
         "\n",
         "# Or simply a file name:\n",
         "model.separate(\"female-female-mixture.wav\")"


### PR DESCRIPTION
fix bug: mixture's dimension does not fit the requirement of model.separate (accept 2- or 3-dimensional array)