### PR TITLE
Drop support for torch<1.8.0

### DIFF
--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -3,7 +3,7 @@
 PyYAML>=5.0
 pandas>=0.23.4
 pytorch-lightning>=1.0.1
-torchaudio>=0.5.0
+torchaudio>=0.8.0
 pb_bss_eval>=0.0.2
 torch_stoi>=0.0.1
 torch_optimizer>=0.0.1a12

--- a/requirements/torchhub.txt
+++ b/requirements/torchhub.txt
@@ -2,8 +2,8 @@
 # Note that Asteroid itself is not required to be installed.
 numpy>=1.16.4
 scipy>=1.1.0
-torch>=1.3.0
-asteroid-filterbanks<0.4.0,>=0.2.4
+torch>=1.8.0
+asteroid-filterbanks>=0.4.0
 requests
 filelock
 SoundFile>=0.10.2


### PR DESCRIPTION
The asteroid-filterbanks 0.4.0 release is the first with torch>=1.8.0 support only, start from there. 