### PR TITLE
[src] Compute linalg beamforming ops in double

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,4 +10,6 @@ repos:
     rev: 20.8b1
     hooks:
       - id: black
+        args:
+        - --config=pyproject.toml
         types: [python]

--- a/asteroid/dsp/beamforming.py
+++ b/asteroid/dsp/beamforming.py
@@ -100,7 +100,7 @@ class SdwMwfBeamformer(BeamFormer):
         target_scm_t = target_scm.permute(0, 3, 1, 2)  # -> bfmm
 
         denominator = target_scm_t + self.mu * noise_scm_t
-        bf_vect, _ = torch.solve(target_scm_t, denominator)
+        bf_vect, _ = stable_solve(target_scm_t, denominator)
         bf_vect = bf_vect[..., ref_mic].transpose(-1, -2)  # -> bfm1  -> bmf
         output = self.apply_beamforming_vector(bf_vect, mix=mix)  # -> bft
         return output

--- a/asteroid/dsp/beamforming.py
+++ b/asteroid/dsp/beamforming.py
@@ -66,7 +66,6 @@ class MvdrBeamformer(BeamFormer):
         noise_scm_t = noise_scm.permute(0, 3, 1, 2)  # -> bfmm
         atf_vec_t = atf_vec.transpose(-1, -2).unsqueeze(-1)  # -> bfm1
 
-        # numerator, _ = torch.solve(atf_vec_t, noise_scm_t)  # -> bfm1
         numerator = stable_solve(atf_vec_t, noise_scm_t)  # -> bfm1
 
         denominator = torch.matmul(atf_vec_t.conj().transpose(-1, -2), numerator)  # -> bf11
@@ -100,7 +99,7 @@ class SdwMwfBeamformer(BeamFormer):
         target_scm_t = target_scm.permute(0, 3, 1, 2)  # -> bfmm
 
         denominator = target_scm_t + self.mu * noise_scm_t
-        bf_vect, _ = stable_solve(target_scm_t, denominator)
+        bf_vect = stable_solve(target_scm_t, denominator)
         bf_vect = bf_vect[..., ref_mic].transpose(-1, -2)  # -> bfm1  -> bmf
         output = self.apply_beamforming_vector(bf_vect, mix=mix)  # -> bft
         return output

--- a/tests/dsp/beamforming_test.py
+++ b/tests/dsp/beamforming_test.py
@@ -57,4 +57,4 @@ def test_mwf(n_mics, mu):
 
 
 def test_stable_cholesky():
-    stable_cholesky(torch.zeros(2, 2))
+    stable_cholesky(torch.randn(2, 2))

--- a/tests/dsp/beamforming_test.py
+++ b/tests/dsp/beamforming_test.py
@@ -57,4 +57,6 @@ def test_mwf(n_mics, mu):
 
 
 def test_stable_cholesky():
-    stable_cholesky(torch.randn(2, 2))
+    a = torch.randn(3, 3)
+    a = torch.mm(a, a.t())  # make symmetric positive-definite
+    stable_cholesky(a)

--- a/tests/dsp/beamforming_test.py
+++ b/tests/dsp/beamforming_test.py
@@ -58,7 +58,3 @@ def test_mwf(n_mics, mu):
 
 def test_stable_cholesky():
     stable_cholesky(torch.zeros(2, 2))
-    with pytest.warns(RuntimeWarning):
-        stable_cholesky(torch.zeros(2, 2), verbose=True)
-    with pytest.raises(RuntimeError):
-        stable_cholesky(torch.zeros(2, 2), jitter=0.0)


### PR DESCRIPTION
As @popcornell  pointed out, numpy automatically casts to double for solving, and torch doesn't. 

This PR makes sure that all the solve, cholesky and inverse ops are done in double (float or complex). 