### PR TITLE
Improve Beamforming naming and add TODOs

### DIFF
--- a/asteroid/dsp/__init__.py
+++ b/asteroid/dsp/__init__.py
@@ -1,5 +1,13 @@
 from .consistency import mixture_consistency
 from .overlap_add import LambdaOverlapAdd, DualPathProcessing
+from .beamforming import (
+    SCM,
+    Beamformer,
+    RTFMVDRBeamformer,
+    SoudenMVDRBeamformer,
+    SDWMWFBeamformer,
+    GEVBeamformer,
+)
 
 __all__ = [
     "mixture_consistency",

--- a/tests/dsp/beamforming_test.py
+++ b/tests/dsp/beamforming_test.py
@@ -3,10 +3,10 @@ import pytest
 from asteroid_filterbanks import make_enc_dec, transforms as tr
 
 from asteroid.dsp.beamforming import (
-    BeamFormer,
+    Beamformer,
     SCM,
-    MvdrBeamformer,
-    SdwMwfBeamformer,
+    RTFMVDRBeamformer,
+    SDWMWFBeamformer,
     GEVBeamformer,
     stable_cholesky,
 )
@@ -20,7 +20,7 @@ istft = lambda x: _istft(tr.from_torch_complex(x))
 
 
 @pytest.mark.skipif(not torch_has_complex_support, "No complex support ")
-def _default_beamformer_test(beamformer: BeamFormer, n_mics=4, *args, **kwargs):
+def _default_beamformer_test(beamformer: Beamformer, n_mics=4, *args, **kwargs):
     scm = SCM()
 
     speech = torch.randn(1, n_mics, 16000 * 6)
@@ -46,14 +46,14 @@ def test_gev(n_mics):
 @pytest.mark.skipif(not torch_has_complex_support, reason="No complex support ")
 @pytest.mark.parametrize("n_mics", [2, 3, 4])
 def test_mvdr(n_mics):
-    _default_beamformer_test(MvdrBeamformer(), n_mics=n_mics)
+    _default_beamformer_test(RTFMVDRBeamformer(), n_mics=n_mics)
 
 
 @pytest.mark.skipif(not torch_has_complex_support, reason="No complex support ")
 @pytest.mark.parametrize("n_mics", [2, 3, 4])
 @pytest.mark.parametrize("mu", [1.0, 2.0, 0])
 def test_mwf(n_mics, mu):
-    _default_beamformer_test(SdwMwfBeamformer(mu=mu), n_mics=n_mics)
+    _default_beamformer_test(SDWMWFBeamformer(mu=mu), n_mics=n_mics)
 
 
 def test_stable_cholesky():


### PR DESCRIPTION
We had a small vote on the slack channel and all caps for abbreviations in class names are more unanimous. 

Also change atf to rtf in function names because it's closer to reality.
And add placeholder code for @popcornell `SoudenMVDRBeamformer`.