### PR TITLE
[instal] Bump lightning version under 1.3.0

### DIFF
--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -2,7 +2,7 @@
 -r ./torchhub.txt
 PyYAML>=5.0
 pandas>=0.23.4
-pytorch-lightning>=1.0.1
+pytorch-lightning>=1.0.1,<1.3.0
 torchaudio>=0.8.0
 pb_bss_eval>=0.0.2
 torch_stoi>=0.0.1

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         # From requirements/install.txt
         "PyYAML>=5.0",
         "pandas>=0.23.4",
-        "pytorch-lightning>=1.0.1",
+        "pytorch-lightning>=1.0.1,<1.3.0",
         "torchaudio>=0.5.0",
         "pb_bss_eval>=0.0.2",
         "torch_stoi>=0.1.2",


### PR DESCRIPTION
The tests are failing for now so something is broken. 
We'll have to do a release for lightning<1.3.0, and fix what's broken and upgrade. 


Indentified in #492 