### PR TITLE
Fix default norm_type for causal ConvTasNet

### DIFF
--- a/asteroid/models/conv_tasnet.py
+++ b/asteroid/models/conv_tasnet.py
@@ -83,7 +83,7 @@ class ConvTasNet(BaseEncoderMaskerDecoder):
                 "be the same. Received "
                 f"{n_feats} and {in_chan}"
             )
-        if causal and norm_type != "cgLN":
+        if causal and norm_type not in ['cgLN', 'cLN']:
             norm_type = "cgLN"
             warnings.warn(
                 "In causal configuration cumulative layer normalization (cgLN)"

--- a/asteroid/models/conv_tasnet.py
+++ b/asteroid/models/conv_tasnet.py
@@ -82,6 +82,11 @@ class ConvTasNet(BaseEncoderMaskerDecoder):
                 "be the same. Received "
                 f"{n_feats} and {in_chan}"
             )
+        if causal and norm_type != 'cgLN':
+            norm_type = 'cgLN'
+            print(
+                "In causal configuration cumulative layer normalization"
+                f"must be used. Changing f{norm_type} to cgLN")
         # Update in_chan
         masker = TDConvNet(
             n_feats,

--- a/asteroid/models/conv_tasnet.py
+++ b/asteroid/models/conv_tasnet.py
@@ -1,6 +1,7 @@
 from asteroid_filterbanks import make_enc_dec
 from ..masknn import TDConvNet
 from .base_models import BaseEncoderMaskerDecoder
+import warnings
 
 
 class ConvTasNet(BaseEncoderMaskerDecoder):
@@ -84,8 +85,9 @@ class ConvTasNet(BaseEncoderMaskerDecoder):
             )
         if causal and norm_type != "cgLN":
             norm_type = "cgLN"
-            print(
-                "In causal configuration cumulative layer normalization"
+            warnings.warn(
+                "In causal configuration cumulative layer normalization (cgLN)"
+                "or channel-wise Layer Normalization (chanLN)  "
                 f"must be used. Changing f{norm_type} to cgLN"
             )
         # Update in_chan

--- a/asteroid/models/conv_tasnet.py
+++ b/asteroid/models/conv_tasnet.py
@@ -82,11 +82,12 @@ class ConvTasNet(BaseEncoderMaskerDecoder):
                 "be the same. Received "
                 f"{n_feats} and {in_chan}"
             )
-        if causal and norm_type != 'cgLN':
-            norm_type = 'cgLN'
+        if causal and norm_type != "cgLN":
+            norm_type = "cgLN"
             print(
                 "In causal configuration cumulative layer normalization"
-                f"must be used. Changing f{norm_type} to cgLN")
+                f"must be used. Changing f{norm_type} to cgLN"
+            )
         # Update in_chan
         masker = TDConvNet(
             n_feats,

--- a/asteroid/models/conv_tasnet.py
+++ b/asteroid/models/conv_tasnet.py
@@ -83,7 +83,7 @@ class ConvTasNet(BaseEncoderMaskerDecoder):
                 "be the same. Received "
                 f"{n_feats} and {in_chan}"
             )
-        if causal and norm_type not in ['cgLN', 'cLN']:
+        if causal and norm_type not in ["cgLN", "cLN"]:
             norm_type = "cgLN"
             warnings.warn(
                 "In causal configuration cumulative layer normalization (cgLN)"


### PR DESCRIPTION
This is to avoid using any non causal  `norm_type` when `causal=True`.