### PR TITLE
``asteroid.filterbanks`` to ``asteroid_filterbanks``

### DIFF
--- a/notebooks/01_APIOverview.ipynb
+++ b/notebooks/01_APIOverview.ipynb
@@ -84,7 +84,7 @@
    },
    "outputs": [],
    "source": [
-    "from asteroid.filterbanks import STFTFB, Encoder, Decoder\n",
+    "from asteroid_filterbanks import STFTFB, Encoder, Decoder\n",
     "# First, instantiate the STFT filterbank\n",
     "fb = STFTFB(n_filters=256, kernel_size=128, stride=64)\n",
     "# Make an encoder out of it, forward some waveform through it.\n",
@@ -94,7 +94,7 @@
     "decoder = Decoder(decoder_fb)\n",
     "\n",
     "# The preceding lines can also be obtained faster with these lines\n",
-    "from asteroid.filterbanks import make_enc_dec\n",
+    "from asteroid_filterbanks import make_enc_dec\n",
     "encoder, decoder = make_enc_dec('stft', n_filters=256, \n",
     "                                kernel_size=128, stride=64)\n",
     "\n"
@@ -203,7 +203,7 @@
    },
    "outputs": [],
    "source": [
-    "from asteroid.filterbanks import make_enc_dec\n",
+    "from asteroid_filterbanks import make_enc_dec\n",
     "\n",
     "class Model(torch.nn.Module):\n",
     "    def __init__(self):\n",

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -8,7 +8,6 @@ You can find here a list of Asteroid's notebooks that explain some concepts, des
 | [Filterbank API](https://github.com/asteroid-team/asteroid/blob/master/notebooks/02_Filterbank.ipynb)  | Description of the Filterbank API + How to write your own  |[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](http://colab.research.google.com/github/asteroid-team/asteroid/blob/master/notebooks/02_Filterbank.ipynb) |
 | [PITLossWrapper](https://github.com/asteroid-team/asteroid/blob/master/notebooks/.ipynb)  |  Permutation invariant losses explained + how to extend your losses |[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](http://colab.research.google.com/github/asteroid-team/asteroid/blob/master/notebooks/03_PITLossWrapper.ipynb) |
 | [Process large files](https://github.com/asteroid-team/asteroid/blob/master/notebooks/04_ProcessLargeAudioFiles.ipynb)  | Processing large wav files with pretrained models |[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](http://colab.research.google.com/github/asteroid-team/asteroid/blob/master/notebooks/04_ProcessLargeAudioFiles.ipynb) |
-| [](https://github.com/asteroid-team/asteroid/blob/master/notebooks/)  |   |[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](http://colab.research.google.com/github/asteroid-team/asteroid/blob/master/examples/) |
 
 
 If you wrote some notebook(s) using Asteroid, we'd love to have it here, open a PR! :star:


### PR DESCRIPTION
``asteroid.filterbanks`` to ``asteroid_filterbanks``

This PR is with the issue "No module named 'asteroid.filterbanks' #525"