### PR TITLE
[install] pytorch-optimizer dropped RAdam

### DIFF
--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -6,5 +6,5 @@ pytorch-lightning>=1.0.1
 torchaudio>=0.8.0
 pb_bss_eval>=0.0.2
 torch_stoi>=0.0.1
-torch_optimizer>=0.0.1a12
+torch_optimizer>=0.0.1a12,<0.2.0
 julius

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         "torchaudio>=0.5.0",
         "pb_bss_eval>=0.0.2",
         "torch_stoi>=0.1.2",
-        "torch_optimizer>=0.0.1a12",
+        "torch_optimizer>=0.0.1a12,<0.2.0",
         "julius",
     ],
     entry_points={


### PR DESCRIPTION
In jettify/pytorch-optimizer#377 the RAdam optimizer was removed from pytorch-optimizer, it's still used in asteroid though. So we restrict the version to be earlier than 0.2.0. 