### PR TITLE
Fix documentation deep_clustering_loss example

### DIFF
--- a/asteroid/losses/cluster.py
+++ b/asteroid/losses/cluster.py
@@ -20,7 +20,7 @@ def deep_clustering_loss(embedding, tgt_index, binary_mask=None):
         >>> from asteroid.losses.cluster import deep_clustering_loss
         >>> spk_cnt = 3
         >>> embedding = torch.randn(10, 5*400, 20)
-        >>> targets = torch.LongTensor([10, 400, 5]).random_(0, spk_cnt)
+        >>> targets = torch.LongTensor(10, 400, 5).random_(0, spk_cnt)
         >>> loss = deep_clustering_loss(embedding, targets)
 
     Reference


### PR DESCRIPTION
This solves the documentation issue #591 
In the example, the arguments where being passed as a list while the function expected three separate arguments, as explained on the comments of the issue. 
