### PR TITLE
Raise PL requirement to 1.3.0

### DIFF
--- a/asteroid/engine/schedulers.py
+++ b/asteroid/engine/schedulers.py
@@ -28,7 +28,7 @@ class BaseScheduler(object):
         for param_group in self.optimizer.param_groups:
             param_group["lr"] = lr
 
-    def step(self):
+    def step(self, metrics=None, epoch=None):
         """Update step-wise learning rate before optimizer.step."""
         self.step_num += 1
         lr = self._get_lr()

--- a/asteroid/engine/system.py
+++ b/asteroid/engine/system.py
@@ -5,6 +5,7 @@ from torch.optim.lr_scheduler import ReduceLROnPlateau
 from ..utils import flatten_dict
 from .schedulers import BaseScheduler
 
+
 class System(pl.LightningModule):
     """Base class for deep learning systems.
     Contains a model, an optimizer, a loss function, training and validation
@@ -164,9 +165,7 @@ class System(pl.LightningModule):
         return [self.optimizer], epoch_schedulers
 
     def lr_scheduler_step(self, scheduler, optimizer_idx, metric):
-        if isinstance(scheduler, BaseScheduler):
-            scheduler.step()
-        elif metric is None:
+        if metric is None:
             scheduler.step()
         else:
             scheduler.step(metric)

--- a/asteroid/engine/system.py
+++ b/asteroid/engine/system.py
@@ -3,7 +3,6 @@ import pytorch_lightning as pl
 from torch.optim.lr_scheduler import ReduceLROnPlateau
 
 from ..utils import flatten_dict
-from .schedulers import BaseScheduler
 
 
 class System(pl.LightningModule):

--- a/asteroid/engine/system.py
+++ b/asteroid/engine/system.py
@@ -3,7 +3,7 @@ import pytorch_lightning as pl
 from torch.optim.lr_scheduler import ReduceLROnPlateau
 
 from ..utils import flatten_dict
-
+from .schedulers import BaseScheduler
 
 class System(pl.LightningModule):
     """Base class for deep learning systems.
@@ -162,6 +162,14 @@ class System(pl.LightningModule):
                 ], "Scheduler interval should be either step or epoch"
                 epoch_schedulers.append(sched)
         return [self.optimizer], epoch_schedulers
+
+    def lr_scheduler_step(self, scheduler, optimizer_idx, metric):
+        if isinstance(scheduler, BaseScheduler):
+            scheduler.step()
+        elif metric is None:
+            scheduler.step()
+        else:
+            scheduler.step(metric)
 
     def train_dataloader(self):
         """Training dataloader"""

--- a/asteroid/engine/system.py
+++ b/asteroid/engine/system.py
@@ -163,12 +163,6 @@ class System(pl.LightningModule):
                 epoch_schedulers.append(sched)
         return [self.optimizer], epoch_schedulers
 
-    def lr_scheduler_step(self, scheduler, optimizer_idx, metric):
-        if metric is None:
-            scheduler.step()
-        else:
-            scheduler.step(metric)
-
     def train_dataloader(self):
         """Training dataloader"""
         return self.train_loader

--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -2,7 +2,7 @@
 -r ./torchhub.txt
 PyYAML>=5.0
 pandas>=0.23.4
-pytorch-lightning>=1.3.0
+pytorch-lightning>=1.5.0
 torchaudio>=0.8.0
 pb_bss_eval>=0.0.2
 torch_stoi>=0.0.1

--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -2,7 +2,7 @@
 -r ./torchhub.txt
 PyYAML>=5.0
 pandas>=0.23.4
-pytorch-lightning>=1.0.1,<1.5.0
+pytorch-lightning>=1.3.0
 torchaudio>=0.8.0
 pb_bss_eval>=0.0.2
 torch_stoi>=0.0.1

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         # From requirements/install.txt
         "PyYAML>=5.0",
         "pandas>=0.23.4",
-        "pytorch-lightning>=1.0.1,<1.5.0",
+        "pytorch-lightning>=1.3.0",
         "torchaudio>=0.5.0",
         "pb_bss_eval>=0.0.2",
         "torch_stoi>=0.1.2",

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         # From requirements/install.txt
         "PyYAML>=5.0",
         "pandas>=0.23.4",
-        "pytorch-lightning>=1.3.0",
+        "pytorch-lightning>=1.5.0",
         "torchaudio>=0.5.0",
         "pb_bss_eval>=0.0.2",
         "torch_stoi>=0.1.2",

--- a/tests/losses/sinkpit_wrapper_test.py
+++ b/tests/losses/sinkpit_wrapper_test.py
@@ -104,7 +104,7 @@ class _TestCallback(pl.callbacks.Callback):
         assert self.epoch * self.n_batch <= step
         assert step <= (self.epoch + 1) * self.n_batch
 
-    def on_train_epoch_end(self, trainer, pl_module, outputs):
+    def on_train_epoch_end(self, trainer, pl_module):
         epoch = trainer.current_epoch
         assert epoch == self.epoch
         assert pl_module.loss_func.beta == self.f(epoch)


### PR DESCRIPTION
- Remove the deprecated `output` parameter from `on_train_epoch_end`
- Add a simple custom `lr_scheduler_step` to the base model
- Remove the PL upper version constraint

This allows also torchmetrics to follow PL, which caused problems when PL was pinned and not torchmetrics.