### PR TITLE
Restrict jinja2>=3.0.0,<3.1.0

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -3,6 +3,7 @@ sphinx-rtd-theme==0.4.3
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-programoutput>=0.16
 sphinx>=1.8.3, <3.0
+jinja2>=3.0.0,<3.1.0
 recommonmark  # fails with badges
 nbsphinx
 m2r2


### PR DESCRIPTION
Jinja problem from [here](https://github.com/sphinx-doc/sphinx/issues/10291)

This should fix docs build