### PR TITLE
Update overlap_add.py, auto casting device for window

### DIFF
--- a/asteroid/dsp/overlap_add.py
+++ b/asteroid/dsp/overlap_add.py
@@ -113,7 +113,7 @@ class LambdaOverlapAdd(torch.nn.Module):
                 frame = _reorder_sources(frame, out[-1], n_src, self.window_size, self.hop_size)
 
             if self.use_window:
-                frame = frame * self.window
+                frame = frame * self.window.to(frame)
             else:
                 frame = frame / (self.window_size / self.hop_size)
             out.append(frame)


### PR DESCRIPTION
allows to use LambdaOverlapAdd also on GPU without calling before .to on the instantiated module.