### PR TITLE
_reorder_sources() in OLA compares scaled/windowed frame with un-scaled/un-windowed frame

### DIFF
--- a/asteroid/dsp/overlap_add.py
+++ b/asteroid/dsp/overlap_add.py
@@ -114,7 +114,7 @@ class LambdaOverlapAdd(torch.nn.Module):
 
             out.append(frame)
 
-        # apply windowing/scaling *after* _reorder_sources has been called.
+        # apply windowing/scaling *after* _reorder_sources has been called, inplace.
         for frame in out:
             if self.use_window:
                 frame *= self.window.to(frame)

--- a/asteroid/dsp/overlap_add.py
+++ b/asteroid/dsp/overlap_add.py
@@ -112,11 +112,14 @@ class LambdaOverlapAdd(torch.nn.Module):
                 # we determine best perm based on xcorr with previous sources
                 frame = _reorder_sources(frame, out[-1], n_src, self.window_size, self.hop_size)
 
-            if self.use_window:
-                frame = frame * self.window.to(frame)
-            else:
-                frame = frame / (self.window_size / self.hop_size)
             out.append(frame)
+
+        # apply windowing/scaling *after* _reorder_sources has been called.
+        for frame in out:
+            if self.use_window:
+                frame *= self.window.to(frame)
+            else:
+                frame /= self.window_size / self.hop_size
 
         out = torch.stack(out).reshape(n_chunks, batch * n_src, self.window_size)
         out = out.permute(1, 2, 0)


### PR DESCRIPTION
Hey there,

`_reorder_sources()` is called with the *current* and the *previous* frames as arguments. The way it had been coded, the previous frame might have been scaled or windowed already. But to get best results, we probably want to compare to an unscaled, un-windowed version. That's what this change fixes.

Cheers.