### PR TITLE
Make a docstring a raw-string to avoid a syntax warning

### DIFF
--- a/asteroid/masknn/tac.py
+++ b/asteroid/masknn/tac.py
@@ -4,7 +4,7 @@ from . import activations, norms
 
 
 class TAC(nn.Module):
-    """Transform-Average-Concatenate inter-microphone-channel permutation invariant communication block [1].
+    r"""Transform-Average-Concatenate inter-microphone-channel permutation invariant communication block [1].
 
     Args:
         input_dim (int): Number of features of input representation.


### PR DESCRIPTION
An example of the SyntaxWarning messages I was getting:
```
/usr/local/lib/python3.12/site-packages/asteroid/masknn/tac.py:15: SyntaxWarning: invalid escape sequence '\_'
  .. note:: Supports inputs of shape :math:`(batch, mic\_channels, features, chunk\_size, n\_chunks)`
/usr/local/lib/python3.12/site-packages/asteroid/masknn/tac.py:42: SyntaxWarning: invalid escape sequence '\_'
  Shape: :math:`(batch, mic\_channels, features, chunk\_size, n\_chunks)`.
```