### PR TITLE
Fix TypeError: numpy.float64 cannot be interpreted as integer

### DIFF
--- a/asteroid/masknn/recurrent.py
+++ b/asteroid/masknn/recurrent.py
@@ -676,7 +676,7 @@ class DCCRMaskNet(BaseDCUMaskNet):
         super().__init__(
             encoders=[
                 *(DCUNetComplexEncoderBlock(*args, activation="prelu") for args in encoders),
-                DCCRMaskNetRNN(np.prod(last_encoder_out_shape)),
+                DCCRMaskNetRNN(int(np.prod(last_encoder_out_shape))),
             ],
             decoders=[
                 torch.nn.Identity(),

--- a/asteroid/models/conv_tasnet.py
+++ b/asteroid/models/conv_tasnet.py
@@ -76,7 +76,7 @@ class ConvTasNet(BaseEncoderMaskerDecoder):
             sample_rate=sample_rate,
             **fb_kwargs,
         )
-        n_feats = encoder.n_feats_out
+        n_feats = int(encoder.n_feats_out)
         if in_chan is not None:
             assert in_chan == n_feats, (
                 "Number of filterbank output channels"

--- a/asteroid/models/dccrnet.py
+++ b/asteroid/models/dccrnet.py
@@ -24,7 +24,7 @@ class DCCRNet(BaseDCUNet):
     def __init__(
         self, *args, stft_n_filters=512, stft_kernel_size=400, stft_stride=100, **masknet_kwargs
     ):
-        masknet_kwargs.setdefault("n_freqs", stft_n_filters // 2)
+        masknet_kwargs.setdefault("n_freqs", int(stft_n_filters) // 2)
         super().__init__(
             *args,
             stft_n_filters=stft_n_filters,

--- a/asteroid/models/demask.py
+++ b/asteroid/models/demask.py
@@ -61,8 +61,9 @@ class DeMask(BaseEncoderMaskerDecoder):
             **fb_kwargs,
         )
 
-        n_masker_in = self._get_n_feats_input(input_type, encoder.n_feats_out)
-        n_masker_out = self._get_n_feats_output(output_type, encoder.n_feats_out)
+        n_feats_out = int(encoder.n_feats_out)
+        n_masker_in = self._get_n_feats_input(input_type, n_feats_out)
+        n_masker_out = self._get_n_feats_output(output_type, n_feats_out)
         masker = build_demask_masker(
             n_masker_in,
             n_masker_out,

--- a/asteroid/models/dprnn_tasnet.py
+++ b/asteroid/models/dprnn_tasnet.py
@@ -82,7 +82,7 @@ class DPRNNTasNet(BaseEncoderMaskerDecoder):
             sample_rate=sample_rate,
             **fb_kwargs,
         )
-        n_feats = encoder.n_feats_out
+        n_feats = int(encoder.n_feats_out)
         if in_chan is not None:
             assert in_chan == n_feats, (
                 "Number of filterbank output channels"

--- a/asteroid/models/dptnet.py
+++ b/asteroid/models/dptnet.py
@@ -79,7 +79,7 @@ class DPTNet(BaseEncoderMaskerDecoder):
             sample_rate=sample_rate,
             **fb_kwargs,
         )
-        n_feats = encoder.n_feats_out
+        n_feats = int(encoder.n_feats_out)
         if in_chan is not None:
             assert in_chan == n_feats, (
                 "Number of filterbank output channels"

--- a/asteroid/models/lstm_tasnet.py
+++ b/asteroid/models/lstm_tasnet.py
@@ -68,7 +68,7 @@ class LSTMTasNet(BaseEncoderMaskerDecoder):
             sample_rate=sample_rate,
             **fb_kwargs,
         )
-        n_feats = encoder.n_feats_out
+        n_feats = int(encoder.n_feats_out)
         if in_chan is not None:
             assert in_chan == n_feats, (
                 "Number of filterbank output channels"

--- a/asteroid/models/sudormrf.py
+++ b/asteroid/models/sudormrf.py
@@ -62,7 +62,7 @@ class SuDORMRFNet(BaseEncoderMaskerDecoder):
             output_padding=(kernel_size // 2) - 1,
             **fb_kwargs,
         )
-        n_feats = enc.n_feats_out
+        n_feats = int(enc.n_feats_out)
         enc = _Padder(enc, upsampling_depth=upsampling_depth, kernel_size=kernel_size)
 
         if in_chan is not None:
@@ -136,7 +136,7 @@ class SuDORMRFImprovedNet(BaseEncoderMaskerDecoder):
             output_padding=(kernel_size // 2) - 1,
             **fb_kwargs,
         )
-        n_feats = enc.n_feats_out
+        n_feats = int(enc.n_feats_out)
         enc = _Padder(enc, upsampling_depth=upsampling_depth, kernel_size=kernel_size)
 
         if in_chan is not None:

--- a/asteroid/models/x_umx.py
+++ b/asteroid/models/x_umx.py
@@ -73,7 +73,7 @@ class XUMX(BaseModel):
         self.nb_channels = nb_channels
         self.nb_layers = nb_layers
         self.bidirectional = bidirectional
-        self.nb_output_bins = in_chan // 2 + 1
+        self.nb_output_bins = int(in_chan) // 2 + 1
         if max_bin:
             self.max_bin = max_bin
         else:

--- a/egs/dns_challenge_INTERSPEECH2020/baseline/model.py
+++ b/egs/dns_challenge_INTERSPEECH2020/baseline/model.py
@@ -28,7 +28,7 @@ def make_model_and_optimizer(conf):
     # Because we concatenate (re, im, mag) as input and compute a complex mask.
     if conf["main_args"]["is_complex"]:
         inp_size = int(stft.n_feats_out * 3 / 2)
-        output_size = stft.n_feats_out
+        output_size = int(stft.n_feats_out)
     else:
         inp_size = output_size = int(stft.n_feats_out / 2)
     # Add these fields to the mask model dict

--- a/egs/wsj0-mix/DeepClustering/model.py
+++ b/egs/wsj0-mix/DeepClustering/model.py
@@ -23,7 +23,7 @@ def make_model_and_optimizer(conf):
     and evaluation very simple.
     """
     enc, dec = fb.make_enc_dec("stft", **conf["filterbank"])
-    masker = Chimera(enc.n_feats_out // 2, **conf["masknet"])
+    masker = Chimera(int(enc.n_feats_out) // 2, **conf["masknet"])
     model = Model(enc, masker, dec)
     optimizer = make_optimizer(model.parameters(), **conf["optim"])
     return model, optimizer


### PR DESCRIPTION
## Summary

- **Fixes #713**: Cast `encoder.n_feats_out` and similar values to `int()` across all model constructors and recipe files to prevent `TypeError: 'numpy.float64' object cannot be interpreted as an integer`.
- Newer NumPy versions return `numpy.float64` scalars from arithmetic operations, which PyTorch's `nn.Conv1d`, `nn.Parameter`, `torch.ones()`, and other APIs reject where a native Python `int` is expected.
- This is a minimal, targeted fix that wraps the filterbank output channel count with `int()` at the point of use, ensuring compatibility without changing any behavior.

## Changes

**Core model files** (`asteroid/models/`):
- `dprnn_tasnet.py`: `n_feats = int(encoder.n_feats_out)`
- `conv_tasnet.py`: `n_feats = int(encoder.n_feats_out)`
- `dptnet.py`: `n_feats = int(encoder.n_feats_out)`
- `lstm_tasnet.py`: `n_feats = int(encoder.n_feats_out)`
- `sudormrf.py`: `n_feats = int(enc.n_feats_out)` (both `SuDORMRFNet` and `SuDORMRFImprovedNet`)
- `demask.py`: `n_feats_out = int(encoder.n_feats_out)` before passing to helper methods
- `dccrnet.py`: `int(stft_n_filters) // 2`
- `x_umx.py`: `int(in_chan) // 2 + 1`

**Mask network** (`asteroid/masknn/`):
- `recurrent.py`: `int(np.prod(last_encoder_out_shape))` in `DCCRMaskNet`

**Recipe/example files** (`egs/`):
- `dns_challenge_INTERSPEECH2020/baseline/model.py`: `output_size = int(stft.n_feats_out)`
- `wsj0-mix/DeepClustering/model.py`: `int(enc.n_feats_out) // 2`

## Test plan

- [x] Verified the exact reproduction case from #713 (`DPRNNTasNet(n_src=2)` construction) no longer raises `TypeError`
- [x] All changes are safe no-ops when `n_feats_out` is already a Python `int`
- [x] Checked all usages of `n_feats_out` across the codebase for completeness